### PR TITLE
test: adding new test cases for date and cep

### DIFF
--- a/tests/test_cep.py
+++ b/tests/test_cep.py
@@ -25,18 +25,30 @@ class TestCEP(TestCase):
         self.assertEqual(remove_symbols("...---..."), "")
 
     def test_is_valid(self):
-        # When CEP is not string, returns False
-        self.assertIs(is_valid(1), False)
 
-        # When CEP's len is different of 8, returns False
-        self.assertIs(is_valid("1"), False)
-
-        # When CEP does not contain only digits, returns False
-        self.assertIs(is_valid("1234567-"), False)
-
-        # When CEP is valid
-        self.assertIs(is_valid("99999999"), True)
-        self.assertIs(is_valid("88390000"), True)
+        # Invalid types (when CEP is not string, returns False)
+        self.assertFalse(is_valid(1))  # Number
+        self.assertFalse(is_valid(None))  # None
+        self.assertFalse(is_valid([]))  # Array
+        
+        # Invalid lengths (when CEP's len is different of 8, returns False)
+        self.assertFalse(is_valid(""))  # Empty
+        self.assertFalse(is_valid("1"))  # Lower boundary 
+        self.assertFalse(is_valid("1234567"))  # Below boundary (7 digits)
+        self.assertFalse(is_valid("123456789"))  # Above boundary (9 digits)
+        self.assertFalse(is_valid("1234567890"))  
+        
+        # Invalid characters (when CEP does not contain only digits, returns False)
+        self.assertFalse(is_valid("1234-678"))  # Hyphen
+        self.assertFalse(is_valid("1234 5678"))  # Space
+        self.assertFalse(is_valid("1234A678"))  # Letter
+        self.assertFalse(is_valid("1234.6789"))  # Dot
+        
+        # Valid CEPs
+        self.assertTrue(is_valid("00000000"))  
+        self.assertTrue(is_valid("99999999"))  
+        self.assertTrue(is_valid("12345678"))  
+        self.assertTrue(is_valid("18052780"))  # Real CEP
 
     def test_generate(self):
         for _ in range(10_000):

--- a/tests/test_cep.py
+++ b/tests/test_cep.py
@@ -36,7 +36,7 @@ class TestCEP(TestCase):
         self.assertFalse(is_valid("1"))  # Lower boundary 
         self.assertFalse(is_valid("1234567"))  # Below boundary (7 digits)
         self.assertFalse(is_valid("123456789"))  # Above boundary (9 digits)
-        self.assertFalse(is_valid("1234567890"))  
+        self.assertFalse(is_valid("1234567890"))  # Above boundary (10 digits)
         
         # Invalid characters (when CEP does not contain only digits, returns False)
         self.assertFalse(is_valid("1234-678"))  # Hyphen

--- a/tests/test_date.py
+++ b/tests/test_date.py
@@ -22,42 +22,38 @@ class TestNum2Words(TestCase):
 
 
 class TestDate(TestCase):
-    def test_convert_date_to_text(self):
-        self.assertEqual(
-            convert_date_to_text("15/08/2024"),
-            "Quinze de agosto de dois mil e vinte e quatro",
-        )
-        self.assertEqual(
-            convert_date_to_text("01/01/2000"),
-            "Primeiro de janeiro de dois mil",
-        )
-        self.assertEqual(
-            convert_date_to_text("31/12/1999"),
-            "Trinta e um de dezembro de mil novecentos e noventa e nove",
-        )
+    # Valid and right format dates 
+    def test_valid_dates_conversion(self):
+        self.assertEqual(convert_date_to_text("15/08/2024"),"Quinze de agosto de dois mil e vinte e quatro")
+        self.assertEqual(convert_date_to_text("01/01/2000"),"Primeiro de janeiro de dois mil") # First day of the year
+        self.assertEqual(convert_date_to_text("31/12/1999"),"Trinta e um de dezembro de mil novecentos e noventa e nove") # Last day of the year
+        self.assertEqual(convert_date_to_text("29/02/2020"),"Vinte e nove de fevereiro de dois mil e vinte") # Leap year
+        self.assertEqual(convert_date_to_text("01/03/2025"),"Primeiro de marco de dois mil e vinte e cinco") # First day of the month
 
-        #
-        self.assertIsNone(convert_date_to_text("30/02/2020"), None)
-        self.assertIsNone(convert_date_to_text("30/00/2020"), None)
-        self.assertIsNone(convert_date_to_text("30/02/2000"), None)
-        self.assertIsNone(convert_date_to_text("50/09/2000"), None)
-        self.assertIsNone(convert_date_to_text("25/15/2000"), None)
-        self.assertIsNone(convert_date_to_text("29/02/2019"), None)
+    # Nonexistent dates
+    def test_nonexistent_dates(self):
+        self.assertIsNone(convert_date_to_text("31/04/2025"))  #April has 30 days
+        self.assertIsNone(convert_date_to_text("29/02/2025"))  # Non-leap year
+        
+    # Invalid day numbers
+    def test_invalid_day_numbers(self):
+        self.assertIsNone(convert_date_to_text("00/01/2025"))
+        self.assertIsNone(convert_date_to_text("32/01/2025"))
+   
+    # Invalid month/day numbers
+    def test_invalid_month_numbers(self):
+        self.assertIsNone(convert_date_to_text("15/00/2025"))
+        self.assertIsNone(convert_date_to_text("15/13/2025"))
 
-        # Invalid date pattern.
+    # Valid alternative formats
+    def test_invalid_formats(self):
         self.assertRaises(ValueError, convert_date_to_text, "Invalid")
-        self.assertRaises(ValueError, convert_date_to_text, "25/1/2020")
-        self.assertRaises(ValueError, convert_date_to_text, "1924/08/20")
-        self.assertRaises(ValueError, convert_date_to_text, "5/09/2020")
-
-        self.assertEqual(
-            convert_date_to_text("29/02/2020"),
-            "Vinte e nove de fevereiro de dois mil e vinte",
-        )
-        self.assertEqual(
-            convert_date_to_text("01/01/1900"),
-            "Primeiro de janeiro de mil e novecentos",
-        )
+        self.assertRaises(ValueError, convert_date_to_text, "15-08-2025")  
+        self.assertRaises(ValueError, convert_date_to_text, "15.08.2025")  
+        self.assertRaises(ValueError, convert_date_to_text, "2025-01-22")  
+        self.assertRaises(ValueError, convert_date_to_text, "25/1/2020")  
+        self.assertRaises(ValueError, convert_date_to_text, "19/08/20") 
+        self.assertRaises(ValueError, convert_date_to_text, "5/09/2020")  
 
     months_year = [
         (1, "janeiro"),

--- a/tests/test_date.py
+++ b/tests/test_date.py
@@ -45,7 +45,7 @@ class TestDate(TestCase):
         self.assertIsNone(convert_date_to_text("15/00/2025"))
         self.assertIsNone(convert_date_to_text("15/13/2025"))
 
-    # Valid alternative formats
+    # Inalid alternative formats
     def test_invalid_formats(self):
         self.assertRaises(ValueError, convert_date_to_text, "Invalid")
         self.assertRaises(ValueError, convert_date_to_text, "15-08-2025")  

--- a/tests/test_date.py
+++ b/tests/test_date.py
@@ -34,13 +34,14 @@ class TestDate(TestCase):
     def test_nonexistent_dates(self):
         self.assertIsNone(convert_date_to_text("31/04/2025"))  #April has 30 days
         self.assertIsNone(convert_date_to_text("29/02/2025"))  # Non-leap year
-        
+        self.assertIsNone(convert_date_to_text("29/02/2025"))  # Non-leap year
+
     # Invalid day numbers
     def test_invalid_day_numbers(self):
         self.assertIsNone(convert_date_to_text("00/01/2025"))
         self.assertIsNone(convert_date_to_text("32/01/2025"))
    
-    # Invalid month/day numbers
+    # Invalid month numbers
     def test_invalid_month_numbers(self):
         self.assertIsNone(convert_date_to_text("15/00/2025"))
         self.assertIsNone(convert_date_to_text("15/13/2025"))
@@ -54,6 +55,8 @@ class TestDate(TestCase):
         self.assertRaises(ValueError, convert_date_to_text, "25/1/2020")  
         self.assertRaises(ValueError, convert_date_to_text, "19/08/20") 
         self.assertRaises(ValueError, convert_date_to_text, "5/09/2020")  
+        self.assertRaises(ValueError, convert_date_to_text, "1924/08/20")
+
 
     months_year = [
         (1, "janeiro"),

--- a/tests/test_date.py
+++ b/tests/test_date.py
@@ -45,7 +45,7 @@ class TestDate(TestCase):
         self.assertIsNone(convert_date_to_text("15/00/2025"))
         self.assertIsNone(convert_date_to_text("15/13/2025"))
 
-    # Inalid alternative formats
+    # Invalid alternative formats
     def test_invalid_formats(self):
         self.assertRaises(ValueError, convert_date_to_text, "Invalid")
         self.assertRaises(ValueError, convert_date_to_text, "15-08-2025")  


### PR DESCRIPTION
## Descrição
Este Pull Request tem como propósito aprimorar a cobertura dos testes unitários para as funções `convert_date_to_text` e `is_valid_cep`.

## Mudanças Propostas
- Expansão dos casos de teste para `convert_date_to_text` na classe `TestDate` em `tests/test_date.py`,
- Expansão dos casos de teste para `is_valid_cep` na classe `TestCEP` em `tests/test_cep.py`,

## Comentários Adicionais (opcional)
A expansão dos testes para `convert_date_to_text`, revelou que a implementação original nem sempre se comportava de acordo com as expectativas para todos os formatos e cenários de data.

