### PR TITLE
Feat/support new date formats

### DIFF
--- a/README.md
+++ b/README.md
@@ -644,7 +644,7 @@ False
 Converte uma data em sua representação textual.
 
 Argumentos:
- - date (str): Uma string no formato dd/mm/aaaa
+ - date (str): Uma string nos formatos: dd/mm/aaaa, dd-mm-aaaa, aa.mm.aaaa ou aaaa.mm.dd
 
 Retorna:
  - A represetação textual da data ou None caso a data esteja mal formatada ou a data seja inválida.

--- a/README_EN.md
+++ b/README_EN.md
@@ -460,10 +460,10 @@ Example:
 ## Date
 
 ### convert_date_to_text 
-Convert a brazilian date (dd/mm/yyyy) format in their portuguese textual representation.
+Convert a date in their portuguese textual representation.
 
 Args:
- - date (str): A date in a string format dd/mm/yyyy.
+ - date (str): A date in a string format dd/mm/aaaa, dd-mm-aaaa, aa.mm.aaaa or aaaa.mm.dd
 
 Return:
  - (str) | None: A portuguese textual representation of the date or None case a date is invalid.

--- a/tests/test_cep.py
+++ b/tests/test_cep.py
@@ -25,18 +25,30 @@ class TestCEP(TestCase):
         self.assertEqual(remove_symbols("...---..."), "")
 
     def test_is_valid(self):
-        # When CEP is not string, returns False
-        self.assertIs(is_valid(1), False)
 
-        # When CEP's len is different of 8, returns False
-        self.assertIs(is_valid("1"), False)
-
-        # When CEP does not contain only digits, returns False
-        self.assertIs(is_valid("1234567-"), False)
-
-        # When CEP is valid
-        self.assertIs(is_valid("99999999"), True)
-        self.assertIs(is_valid("88390000"), True)
+        # Invalid types (when CEP is not string, returns False)
+        self.assertFalse(is_valid(1))  # Number
+        self.assertFalse(is_valid(None))  # None
+        self.assertFalse(is_valid([]))  # Array
+        
+        # Invalid lengths (when CEP's len is different of 8, returns False)
+        self.assertFalse(is_valid(""))  # Empty
+        self.assertFalse(is_valid("1"))  # Lower boundary 
+        self.assertFalse(is_valid("1234567"))  # Below boundary (7 digits)
+        self.assertFalse(is_valid("123456789"))  # Above boundary (9 digits)
+        self.assertFalse(is_valid("1234567890"))  
+        
+        # Invalid characters (when CEP does not contain only digits, returns False)
+        self.assertFalse(is_valid("1234-678"))  # Hyphen
+        self.assertFalse(is_valid("1234 5678"))  # Space
+        self.assertFalse(is_valid("1234A678"))  # Letter
+        self.assertFalse(is_valid("1234.6789"))  # Dot
+        
+        # Valid CEPs
+        self.assertTrue(is_valid("00000000"))  
+        self.assertTrue(is_valid("99999999"))  
+        self.assertTrue(is_valid("12345678"))  
+        self.assertTrue(is_valid("18052780"))  # Real CEP
 
     def test_generate(self):
         for _ in range(10_000):

--- a/tests/test_date.py
+++ b/tests/test_date.py
@@ -22,42 +22,38 @@ class TestNum2Words(TestCase):
 
 
 class TestDate(TestCase):
-    def test_convert_date_to_text(self):
-        self.assertEqual(
-            convert_date_to_text("15/08/2024"),
-            "Quinze de agosto de dois mil e vinte e quatro",
-        )
-        self.assertEqual(
-            convert_date_to_text("01/01/2000"),
-            "Primeiro de janeiro de dois mil",
-        )
-        self.assertEqual(
-            convert_date_to_text("31/12/1999"),
-            "Trinta e um de dezembro de mil novecentos e noventa e nove",
-        )
+    # Valid and right format dates 
+    def test_valid_dates_conversion(self):
+        self.assertEqual(convert_date_to_text("15/08/2024"),"Quinze de agosto de dois mil e vinte e quatro")
+        self.assertEqual(convert_date_to_text("01/01/2000"),"Primeiro de janeiro de dois mil") # First day of the year
+        self.assertEqual(convert_date_to_text("31/12/1999"),"Trinta e um de dezembro de mil novecentos e noventa e nove") # Last day of the year
+        self.assertEqual(convert_date_to_text("29/02/2020"),"Vinte e nove de fevereiro de dois mil e vinte") # Leap year
+        self.assertEqual(convert_date_to_text("01/03/2025"),"Primeiro de marco de dois mil e vinte e cinco") # First day of the month
 
-        #
-        self.assertIsNone(convert_date_to_text("30/02/2020"), None)
-        self.assertIsNone(convert_date_to_text("30/00/2020"), None)
-        self.assertIsNone(convert_date_to_text("30/02/2000"), None)
-        self.assertIsNone(convert_date_to_text("50/09/2000"), None)
-        self.assertIsNone(convert_date_to_text("25/15/2000"), None)
-        self.assertIsNone(convert_date_to_text("29/02/2019"), None)
+    # Nonexistent dates
+    def test_nonexistent_dates(self):
+        self.assertIsNone(convert_date_to_text("31/04/2025"))  #April has 30 days
+        self.assertIsNone(convert_date_to_text("29/02/2025"))  # Non-leap year
+        
+    # Invalid day numbers
+    def test_invalid_day_numbers(self):
+        self.assertIsNone(convert_date_to_text("00/01/2025"))
+        self.assertIsNone(convert_date_to_text("32/01/2025"))
+   
+    # Invalid month/day numbers
+    def test_invalid_month_numbers(self):
+        self.assertIsNone(convert_date_to_text("15/00/2025"))
+        self.assertIsNone(convert_date_to_text("15/13/2025"))
 
-        # Invalid date pattern.
+    # Valid alternative formats
+    def test_invalid_formats(self):
         self.assertRaises(ValueError, convert_date_to_text, "Invalid")
-        self.assertRaises(ValueError, convert_date_to_text, "25/1/2020")
-        self.assertRaises(ValueError, convert_date_to_text, "1924/08/20")
-        self.assertRaises(ValueError, convert_date_to_text, "5/09/2020")
-
-        self.assertEqual(
-            convert_date_to_text("29/02/2020"),
-            "Vinte e nove de fevereiro de dois mil e vinte",
-        )
-        self.assertEqual(
-            convert_date_to_text("01/01/1900"),
-            "Primeiro de janeiro de mil e novecentos",
-        )
+        self.assertRaises(ValueError, convert_date_to_text, "15-08-2025")  
+        self.assertRaises(ValueError, convert_date_to_text, "15.08.2025")  
+        self.assertRaises(ValueError, convert_date_to_text, "2025-01-22")  
+        self.assertRaises(ValueError, convert_date_to_text, "25/1/2020")  
+        self.assertRaises(ValueError, convert_date_to_text, "19/08/20") 
+        self.assertRaises(ValueError, convert_date_to_text, "5/09/2020")  
 
     months_year = [
         (1, "janeiro"),

--- a/tests/test_date.py
+++ b/tests/test_date.py
@@ -29,6 +29,9 @@ class TestDate(TestCase):
         self.assertEqual(convert_date_to_text("31/12/1999"),"Trinta e um de dezembro de mil novecentos e noventa e nove") # Last day of the year
         self.assertEqual(convert_date_to_text("29/02/2020"),"Vinte e nove de fevereiro de dois mil e vinte") # Leap year
         self.assertEqual(convert_date_to_text("01/03/2025"),"Primeiro de marco de dois mil e vinte e cinco") # First day of the month
+        self.assertEqual(convert_date_to_text("15-08-2025"),"Quinze de agosto de dois mil e vinte e cinco") # First day of the month
+        self.assertEqual(convert_date_to_text("15.08.2025"),"Quinze de agosto de dois mil e vinte e cinco") # First day of the month
+        self.assertEqual(convert_date_to_text("2025-01-22"),"Vinte e dois de janeiro de dois mil e vinte e cinco") # First day of the month
 
     # Nonexistent dates
     def test_nonexistent_dates(self):
@@ -45,15 +48,14 @@ class TestDate(TestCase):
         self.assertIsNone(convert_date_to_text("15/00/2025"))
         self.assertIsNone(convert_date_to_text("15/13/2025"))
 
-    # Valid alternative formats
+    # Invalid alternative formats
     def test_invalid_formats(self):
         self.assertRaises(ValueError, convert_date_to_text, "Invalid")
-        self.assertRaises(ValueError, convert_date_to_text, "15-08-2025")  
-        self.assertRaises(ValueError, convert_date_to_text, "15.08.2025")  
-        self.assertRaises(ValueError, convert_date_to_text, "2025-01-22")  
-        self.assertRaises(ValueError, convert_date_to_text, "25/1/2020")  
-        self.assertRaises(ValueError, convert_date_to_text, "19/08/20") 
-        self.assertRaises(ValueError, convert_date_to_text, "5/09/2020")  
+        self.assertRaises(ValueError, convert_date_to_text, "19/08/20")
+        self.assertRaises(ValueError, convert_date_to_text, "20200101")
+        self.assertRaises(ValueError, convert_date_to_text, "25/1/2020")
+        self.assertRaises(ValueError, convert_date_to_text, "5/9/2020")
+        self.assertRaises(ValueError, convert_date_to_text, "1/3/2024")
 
     months_year = [
         (1, "janeiro"),


### PR DESCRIPTION
## Descrição
Este Pull Request refatora e aprimora a função `convert_date_to_text` para torná-la mais robusta e compatível com uma variedade maior de formatos de data, mantendo o comportamento de tratamento de erros existente. Além disso, inclui o tratamento certo para os casos de datas inseridas com dia 31 em meses com 30 dias e inseridas com dia 00.

## Mudanças Propostas
- A função `convert_date_to_text` agora suporta os seguintes formatos rígidos de entrada:
    - `dd/mm/yyyy`
    - `dd.mm.yyyy` 
    - `dd-mm-yyyy` 
    - `YYYY-MM-DD` 
- O tratamento de erros foi mantido consistente com o comportamento anterior:
    - Strings que **não correspondem a nenhum dos formatos suportados** lançam um `ValueError`.
    - Datas que estão em um **formato válido mas representam uma data inexistente** continuam retornando `None`.
- Remoção da lógica manual de validação de dias e meses, substituindo-a pela robustez do módulo `datetime`.

## Checklist de Revisão
<!--- Marque as caixas que se aplicam. Você pode deixar caixas desmarcadas se elas não se aplicarem.-->

- [x] Eu li o [Contributing.md](https://github.com/brazilian-utils/brutils-python/blob/main/CONTRIBUTING.md)
- [x] Os testes foram adicionados ou atualizados para refletir as mudanças (se aplicável).
- [ ] Foi adicionada uma entrada no changelog / Meu PR não necessita de uma nova entrada no changelog.
- [x] A [documentação](https://github.com/brazilian-utils/brutils-python/blob/main/README.md) em português foi atualizada ou criada, se necessário.
- [x] Se feita a documentação, a atualização do [arquivo em inglês](https://github.com/brazilian-utils/brutils-python/blob/main/README_EN.md). <!---Permitido uso de Google Tradutor/ChatGPT. -->
- [x] Eu documentei as minhas mudanças no código, adicionando docstrings e comentários. [Instruções](https://github.com/brazilian-utils/brutils-python/blob/main/CONTRIBUTING.md#8-fa%C3%A7a-as-suas-altera%C3%A7%C3%B5es)
- [x] O código segue as diretrizes de estilo e padrões de codificação do projeto.
- [x] Todos os testes passam. [Instruções](https://github.com/brazilian-utils/brutils-python/blob/main/CONTRIBUTING.md#testes)
- [x] O Pull Request foi testado localmente. [Instruções](https://github.com/brazilian-utils/brutils-python/blob/main/CONTRIBUTING.md#7-execute-o-brutils-localmente)
- [x] Não há conflitos de mesclagem.

## Comentários Adicionais (opcional)
Esta implementação otimiza o código da função `convert_date_to_text` ao utilizar as capacidades do módulo `datetime` para validação de datas e anos bissextos. A distinção entre `ValueError` para formatos incorretos e `None` para datas inexistentes foi rigorosamente mantida para preservar a compatibilidade retroativa.

## Issue Relacionada
Aceitar novos cenários de data #5

Closes #5