### PR TITLE
Função 'is_valid' checar a real existência do CEP

### DIFF
--- a/tests/test_cep.py
+++ b/tests/test_cep.py
@@ -50,12 +50,28 @@ class TestCEP(TestCase):
         self.assertTrue(is_valid("12345678"))  
         self.assertTrue(is_valid("18052780"))  # Real CEP
 
+    @patch('brutils.cep.get_address_from_cep')
+    def test_is_valid_with_existence_check(self, mock_get_address):
+        mock_get_address.return_value = {"cep": "18052-780"}
+        self.assertTrue(is_valid("18052780", check_existence=True))
+        mock_get_address.assert_called_once_with("18052780")
+
+        mock_get_address.reset_mock()
+        mock_get_address.return_value = None
+
+        self.assertFalse(is_valid("99999999", check_existence=True))
+        mock_get_address.assert_called_once_with("99999999")
+
+        mock_get_address.reset_mock()
+
+        self.assertFalse(is_valid("12345", check_existence=True))
+        mock_get_address.assert_not_called()
+
     def test_generate(self):
         for _ in range(10_000):
             self.assertIs(is_valid(generate()), True)
 
-
-@patch("brutils.cep.is_valid")
+@patch("brutils.cep._is_valid_format")
 class TestIsValidToFormat(TestCase):
     def test_when_cep_is_valid_returns_True_to_format(self, mock_is_valid):
         mock_is_valid.return_value = True


### PR DESCRIPTION
## Descrição
Este Pull Request aprimora a função de validação de CEP (`is_valid`), adicionando a capacidade de verificar não apenas o formato do código, mas também sua existência real em uma base de dados externa. A nova funcionalidade é opcional e controlada por um parâmetro, garantindo total retrocompatibilidade com o comportamento atual. O objetivo é tornar a validação mais robusta para aplicações que dependem de endereços reais e válidos, como cadastros e sistemas de logística.

## Mudanças Propostas
- Adição do parâmetro opcional `check_existence: bool = False` à função `is_valid` para ativar a validação de existência.
- Implementação da lógica que utiliza a função `get_address_from_cep` para consultar a existência do CEP quando `check_existence` é `True`.
- Refatoração do código para evitar dependência circular: foi criada a função interna `_is_valid_format` e as funções `is_valid`, `get_address_from_cep` e `format_cep` foram atualizadas para utilizá-la.
- Criação de novos testes unitários (`test_is_valid_with_existence_check`) com o uso de `mock` para cobrir todos os cenários da nova funcionalidade (CEP existente, inexistente e de formato inválido).
- Correção dos testes existentes da classe `TestIsValidToFormat` para se alinharem à refatoração, garantindo que o `patch` aponte para a função interna correta (`_is_valid_format`).

## Checklist de Revisão
- [x] Eu li o [Contributing.md](https://github.com/brazilian-utils/brutils-python/blob/main/CONTRIBUTING.md)
- [x] Os testes foram adicionados ou atualizados para refletir as mudanças (se aplicável).
- [ ] Foi adicionada uma entrada no changelog / Meu PR não necessita de uma nova entrada no changelog.
- [ ] A [documentação](https://github.com/brazilian-utils/brutils-python/blob/main/README.md) em português foi atualizada ou criada, se necessário.
- [ ] Se feita a documentação, a atualização do [arquivo em inglês](https://github.com/brazilian-utils/brutils-python/blob/main/README_EN.md).
- [x] Eu documentei as minhas mudanças no código, adicionando docstrings e comentários.
- [x] O código segue as diretrizes de estilo e padrões de codificação do projeto.
- [x] Todos os testes passam.
- [x] O Pull Request foi testado localmente.
- [ ] Não há conflitos de mesclagem.

## Comentários Adicionais (opcional)
Uma parte importante deste PR foi a refatoração para introduzir a função `_is_valid_format`. Essa mudança foi necessária para desacoplar a validação de formato da validação de existência, resolvendo uma dependência circular que impedia a implementação e os testes corretos. Acredito que isso também torna a base de código mais limpa e de fácil manutenção.

## Issue Relacionada
Closes #4